### PR TITLE
fix uprise: potential unfairness sampling & index error of 'hard_neg_ctxs'

### DIFF
--- a/uprise/DPR/dpr/data/biencoder_data.py
+++ b/uprise/DPR/dpr/data/biencoder_data.py
@@ -232,10 +232,10 @@ class UpriseDataset(Dataset):
             # when multi_task == False, 
             # random sample negatives from the same training set, 
             # but avoid choosing those already existed the the positives/hard negatives
+            filtered_prompt_pool = [prompt for prompt in self.prompt_pool if prompt['id'] not in positive_ids + hard_negative_ids]
             negative_cntx = [
                 {"demonstration": self.format_example(n_example, self.prompt_setup_type)}
-                for n_example in random.choices(self.prompt_pool, k=self.top_k)
-                if not n_example["id"] in positive_ids + hard_negative_ids
+                for n_example in random.choices(filtered_prompt_pool, k=self.top_k)
             ]
 
         question = self.format_example(entry, self.task_setup_type)

--- a/uprise/DPR/dpr/models/biencoder.py
+++ b/uprise/DPR/dpr/models/biencoder.py
@@ -196,7 +196,7 @@ class BiEncoder(nn.Module):
             neg_ctxs = neg_ctxs[0:num_other_negatives]
             hard_neg_ctxs = hard_neg_ctxs[0:num_hard_negatives]
 
-            all_ctxs = [positive_ctx] + neg_ctxs + hard_neg_ctxs
+            all_ctxs = [positive_ctx] + hard_neg_ctxs + neg_ctxs
             hard_negatives_start_idx = 1
             hard_negatives_end_idx = 1 + len(hard_neg_ctxs)
 

--- a/uprise/find_random.py
+++ b/uprise/find_random.py
@@ -44,8 +44,7 @@ def find(cfg):
         # `ctxs` stores the sampled prompt ids 
         element["ctxs"] = [
             {"id": int(a)}
-            for a in random.sample(idx_list, k=min(cfg.L, len(data_list)))
-            if int(a) != i # avoid selecting the task input itself
+            for a in random.sample([idx for idx in idx_list if idx != i], k=min(cfg.L, len(data_list)-1)) # avoid selecting the task input itself
         ]
     return data_list
 


### PR DESCRIPTION
Thanks for releasing the code of UPRISE. I have identified some bugs and hope to help fix them!

**1. The potential unfairness caused by random.sample() / random.choice().** In the following code, for each training sample, the lengths of `element["ctxs"]` and `negative_cntx` may not be the same.
```python
# find_random.py line 45
element["ctxs"] = [
    {"id": int(a)}
    for a in random.sample(idx_list, k=min(cfg.L, len(data_list)))
    if int(a) != i # avoid selecting the task input itself
]
# biencoder_data.py line 235
negative_cntx = [
    {"demonstration": self.format_example(n_example, self.prompt_setup_type)}
    for n_example in random.choices(self.prompt_pool, k=self.top_k)
    if not n_example["id"] in positive_ids + hard_negative_ids
]
```

**2. The index error of 'hard_neg_ctxs'.** The `start_idx` and `end_idx` of `hard_neg_ctxs` are wrong when list `neg_ctxs` is not empty.
```python
# biencoder.py line 199
all_ctxs = [positive_ctx] + neg_ctxs + hard_neg_ctxs
hard_negatives_start_idx = 1
hard_negatives_end_idx = 1 + len(hard_neg_ctxs)
```
