### PR TITLE
add a patch for the intergration of qwen and qwen_parallel into minillm

### DIFF
--- a/minillm/minillm/pipelines.py
+++ b/minillm/minillm/pipelines.py
@@ -46,7 +46,7 @@ class PPOPipeline():
         
         assert len(data) <= self.max_prompt_length
         
-        if 65535 in data:
+        if self.args.model_type!="qwen" and 65535 in data:
             source_len = np.where(data==65535)[0][0]
             prompt = data[:source_len]
             response = data[source_len+1:]
@@ -140,7 +140,7 @@ class LMPipeline():
         input_ids = samp["input_ids"]
         source_len = 1
         
-        if 65535 in input_ids:
+        if self.args.model_type!="qwen" and 65535 in input_ids:
             source_len = np.where(input_ids==65535)[0][0]
             input_ids = np.concatenate([input_ids[:source_len], input_ids[source_len+1:]], axis=0)
         input_ids = input_ids[:self.max_length]

--- a/minillm/tools/process_data_dolly.py
+++ b/minillm/tools/process_data_dolly.py
@@ -21,19 +21,33 @@ class Encoder(object):
 
     def encode(self, line):
         line = json.loads(line)
-        if len(line["input"]) == 0:
-            template = (
-                "Below is an instruction that describes a task. "
-                "Write a response that appropriately completes the request.\n\n"
-                "### Instruction:\n{instruction}\n\n### Response:\n"
-            )
+        if "input" not in line or len(line["input"]) == 0:
+            if self.args.model_type!="qwen":
+                template = (
+                    "Below is an instruction that describes a task. "
+                    "Write a response that appropriately completes the request.\n\n"
+                    "### Instruction:\n{instruction}\n\n### Response:\n"
+                )
+            else:
+                template = (
+                    "<|im_start|>Below is an instruction that describes a task. "
+                    "Write a response that appropriately completes the request.\n\n"
+                    "### Instruction:\n{instruction}\n\n### Response:\n<|im_end|><|im_start|>Assistant:"
+                )
             prompt = template.format(instruction=line["instruction"])
         else:
-            template = (
-                "Below is an instruction that describes a task, paired with an input that provides further context. "
-                "Write a response that appropriately completes the request.\n\n"
-                "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:\n"
-            )
+            if self.args.model_type!="qwen":
+                template = (
+                    "Below is an instruction that describes a task, paired with an input that provides further context. "
+                    "Write a response that appropriately completes the request.\n\n"
+                    "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:\n"
+                )
+            else:
+                template = (
+                    "<|im_start|>Below is an instruction that describes a task, paired with an input that provides further context. "
+                    "Write a response that appropriately completes the request.\n\n"
+                    "### Instruction:\n{instruction}\n\n### Input:\n{input}\n\n### Response:\n<|im_end|><|im_start|>Assistant:"
+                )
             prompt = template.format(instruction=line["instruction"], input=line["input"])
             
         response = line["output"]
@@ -82,7 +96,10 @@ def main():
         bin_file = os.path.join(args.processed_data_dir, f"{split}_{0}.bin")
         idx_file = os.path.join(args.processed_data_dir, f"{split}_{0}.idx")
 
-        binary_builder = make_builder(bin_file, impl="mmap", dtype=np.uint16)
+        if args.model_type!="qwen":
+            binary_builder = make_builder(bin_file, impl="mmap", dtype=np.uint16)
+        else:
+            binary_builder = make_builder(bin_file, impl="mmap", dtype=np.uint32)
 
         # put tokenized data into binary_builder
         inst_num = 0

--- a/minillm/tools/process_data_pretrain.py
+++ b/minillm/tools/process_data_pretrain.py
@@ -51,8 +51,12 @@ def main():
     valid_bin_file = os.path.join(args.processed_data_dir, f"valid_{0}.bin")
     valid_idx_file = os.path.join(args.processed_data_dir, f"valid_{0}.idx")
 
-    train_binary_builder = make_builder(train_bin_file, impl="mmap", dtype=np.uint16)
-    valid_binary_builder = make_builder(valid_bin_file, impl="mmap", dtype=np.uint16)
+    if args.model_type!="qwen":
+        train_binary_builder = make_builder(train_bin_file, impl="mmap", dtype=np.uint16)
+        valid_binary_builder = make_builder(valid_bin_file, impl="mmap", dtype=np.uint16)
+    else:
+        train_binary_builder = make_builder(train_bin_file, impl="mmap", dtype=np.uint32)
+        valid_binary_builder = make_builder(valid_bin_file, impl="mmap", dtype=np.uint32)
 
     # put tokenized data into binary_builder
     buffer = []

--- a/minillm/transformers/src/transformers/models/qwen/modeling_qwen.py
+++ b/minillm/transformers/src/transformers/models/qwen/modeling_qwen.py
@@ -525,9 +525,15 @@ class QWenAttention(nn.Module):
                         attention_mask = attention_mask.masked_fill(~causal_mask, torch.finfo(query.dtype).min)
                 else:
                     attention_mask = causal_mask
+                # attn_output = F.scaled_dot_product_attention(
+                #     query, key, value, attn_mask=attention_mask
+                # ).transpose(1, 2)
                 attn_output = F.scaled_dot_product_attention(
-                    query, key, value, attn_mask=attention_mask
-                ).transpose(1, 2)
+                    query.to(torch.float32),
+                    key.to(torch.float32),
+                    value.to(torch.float32),
+                    attn_mask=attention_mask.to(torch.float32)
+                ).to(query.dtype).transpose(1, 2)
                 attn_weight = None
             else:
                 attn_output, attn_weight = self._attn(
@@ -1021,7 +1027,7 @@ class QWenLMHeadModel(QWenPreTrainedModel):
 
     def set_force_gradient_checkpointing(self, value):
         self.transformer.force_gradient_checkpointing = value
-        
+
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,

--- a/minillm/transformers/src/transformers/models/qwen_parallel/modeling_qwen_paralle.py
+++ b/minillm/transformers/src/transformers/models/qwen_parallel/modeling_qwen_paralle.py
@@ -562,9 +562,15 @@ class ParallelQWenAttention(nn.Module):
                         attention_mask = attention_mask.masked_fill(~causal_mask, torch.finfo(query.dtype).min)
                 else:
                     attention_mask = causal_mask
+                # attn_output = F.scaled_dot_product_attention(
+                #     query, key, value, attn_mask=attention_mask
+                # ).transpose(1, 2)
                 attn_output = F.scaled_dot_product_attention(
-                    query, key, value, attn_mask=attention_mask
-                ).transpose(1, 2)
+                    query.to(torch.float32),
+                    key.to(torch.float32),
+                    value.to(torch.float32),
+                    attn_mask=attention_mask.to(torch.float32)
+                ).to(query.dtype).transpose(1, 2)
                 attn_weight = None
             else:
                 attn_output, attn_weight = self._attn(


### PR DESCRIPTION
Add a patch for the PR yesterday (https://github.com/microsoft/LMOps/pull/143)

1. minillm/tools/process_data_dolly.py:  add a prompt template for qwen; use dtype=uint32 instead of uint16 when initialize binary_builder considering the fact that vocab_size of qwen (151936) beyonds the range of uint16 (<= 65535).
2. minillm/tools/process_data_pretrain.py: use dtype=uint32 instead of uint16 when initialize train_binary_builder and valid_binary_builder based on the same reason as above.
3. minillm/minillm/pipelines.py: exclude qwen from the '65535 condition' (line49 and line143) because token_id=65535 has a solid meaning in qwen's tokenizer.
4. minillm/transformers/src/transformers/models/qwen/modeling_qwen.py and minillm/transformers/src/transformers/models/qwen_parallel/modeling_qwen_paralle.py: following the advice from https://github.com/microsoft/LMOps/issues/130#issuecomment-1866089740, I upcast attention to fp32 for more accurate calculations.

BTW, although using fp32, the issue mentioned in #issue130 remains unsolved but I'm actively working on it and hope to have a solution in the near future. Onced sloved, I will submit a new PR.