### PR TITLE
fix(minillm): qwen2 teacher student model unmatched model vocab size

### DIFF
--- a/minillm/finetune.py
+++ b/minillm/finetune.py
@@ -159,6 +159,10 @@ def get_distil_loss(args, tokenizer, model, teacher_model, model_batch, no_model
         teacher_model.eval()
         teacher_outputs = teacher_model(**model_batch, use_cache=False)
         teacher_logits = teacher_outputs.logits
+        if args.model_type  == 'qwen2':
+            # If ZeRO, Get vocab size under module, No ZeRO - directly from config
+            student_vocab_size = model.module.config.vocab_size if hasattr(model, "module") else model.config.vocab_size
+            teacher_logits = teacher_logits[:, :, :student_vocab_size]
     if args.model_parallel:
         distil_losses = mpu.parallel_soft_cross_entropy_loss(logits.float(), teacher_logits.float())
         distil_losses = distil_losses.view(-1)


### PR DESCRIPTION
### Problem Statement
When distilling from teacher model `Qwen/Qwen2.5-7B-Instruct` to student model `Qwen/Qwen2.5-3B`, mismatched model vocab size issue.
```
RuntimeError: The size of tensor a (152064) must match the size of tensor b (151936) at non-singleton dimension 2
```

### Description of Change 

Though both model has same tokenizer vocab size of `151665`, their model vocab size (embedding) are different where `Qwen/Qwen2.5-7B-Instruct` has `152064` and ` Qwen/Qwen2.5-3B` has `151936`. It is safe to truncate the extra padded tokens from the teacher logits (as no real token ID points to them).

Added a conditional fix to handle Qwen2 model types where vocab size mismatch may occur. The change ensures that teacher logits are truncated to match the student’s vocabulary size before loss computation. 
